### PR TITLE
Fix detecting DPI with a capitalized P

### DIFF
--- a/src/Microsoft.Css.Parser/TreeItems/PropertyValues/UnitHelpers.cs
+++ b/src/Microsoft.Css.Parser/TreeItems/PropertyValues/UnitHelpers.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Css.Parser.TreeItems.PropertyValues
 
         private static bool IsDpi(char[] ch, int count)
         {
-            return count == 3 && (ch[0] == 'd' || ch[0] == 'D') && (ch[1] == 'p' || ch[1] == 'p') && (ch[2] == 'i' || ch[2] == 'I');
+            return count == 3 && (ch[0] == 'd' || ch[0] == 'D') && (ch[1] == 'p' || ch[1] == 'P') && (ch[2] == 'i' || ch[2] == 'I');
         }
 
         private static bool IsDpcm(char[] ch, int count)


### PR DESCRIPTION
This was caught by a static code analyzer that noticed that both sides of the or expression (`||`) is the same thing (`ch[1] == 'p'`).